### PR TITLE
shortend cluster name in example to avoid validation errors with gardener

### DIFF
--- a/examples/gardener/main.go
+++ b/examples/gardener/main.go
@@ -24,7 +24,7 @@ func main() {
 	cluster := &types.Cluster{
 		CPU:               1,
 		KubernetesVersion: "1.15.4",
-		Name:              "hydro-cluster",
+		Name:              "hydro",
 		DiskSizeGB:        30,
 		NodeCount:         2,
 		Location:          "europe-west4",

--- a/examples/gcp/main.go
+++ b/examples/gcp/main.go
@@ -22,7 +22,7 @@ func main() {
 
 	cluster := &types.Cluster{
 		KubernetesVersion: "1.13",
-		Name:              "hydro-cluster",
+		Name:              "hydro",
 		DiskSizeGB:        30,
 		NodeCount:         1,
 		Location:          "europe-west3-a",


### PR DESCRIPTION

**Description**

Gardener has a limitation on naming for project and shoot cluster name. To not hit the restriction following the example, the example cluster name must be shortened.

Error unable to provision gardener cluster: unable to provision cluster: 1 error occurred:
        * gardener_gcp_shoot.gardener_cluster: the length of the shoot name and the project name must not exceed 21 characters (project: neighbors; shoot: hydro-cluster)

