### PR TITLE
Fix links in Hydroform examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 
 The following examples show you how to use Hydroform for cluster provisioning:
 
-* [GCP](https://github.com/kyma-incubator/hydroform/tree/master/examples/gcp/main.go)
-* [Gardener/GCP](https://github.com/kyma-incubator/hydroform/blob/master/examples/gardener/gcp/main.go)
-* [Gardener/Azure](https://github.com/kyma-incubator/hydroform/blob/master/examples/gardener/azure/main.go)
-* [Gardener/AKS](https://github.com/kyma-incubator/hydroform/blob/master/examples/gardener/aks/main.go)
+* [GCP](../examples/gcp/README.md)
+* [Gardener/GCP](../examples/gardener/aws/README.md)
+* [Gardener/Azure](../examples/gardener/azure/README.md)
+* [Gardener/AKS](../examples/gardener/gcp/README.md)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix links in Hydroform examples so that they point to README files

Relates to https://github.com/kyma-incubator/hydroform/issues/23