### PR TITLE
Add state recovery and refresh to provision

### DIFF
--- a/provision/internal/operator/terraform/files.go
+++ b/provision/internal/operator/terraform/files.go
@@ -183,7 +183,7 @@ provider "gardener" {
 	kube_file          = "${file("${var.credentials_file_path}")}"
 }
 
-resource "gardener_shoot" "test_cluster" {
+resource "gardener_shoot" "gardener_cluster" {
 	metadata {
 	  name      = "${var.cluster_name}"
 	  namespace = "${var.namespace}"

--- a/provision/internal/operator/terraform/gardener.go
+++ b/provision/internal/operator/terraform/gardener.go
@@ -14,7 +14,7 @@ import (
 // TODO remove this file when the gardener provider is on the official terraform registry
 
 const (
-	providerURL  = "https://github.com/kyma-incubator/terraform-provider-gardener/releases/download/v0.0.3/terraform-provider-gardener-%s-%s"
+	providerURL  = "https://github.com/kyma-incubator/terraform-provider-gardener/releases/download/v0.0.4/terraform-provider-gardener-%s-%s"
 	providerName = "terraform-provider-gardener"
 )
 

--- a/provision/internal/operator/terraform/tfcmd.go
+++ b/provision/internal/operator/terraform/tfcmd.go
@@ -1,0 +1,197 @@
+package terraform
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/hashicorp/terraform/command"
+	"github.com/kyma-incubator/hydroform/provision/types"
+	hashiCli "github.com/mitchellh/cli"
+	"github.com/pkg/errors"
+)
+
+// tfInit runs the 'terraform init' command with the specified options and config in the given working directory
+func tfInit(ops Options, p types.ProviderType, cfg map[string]interface{}, dir string) error {
+	i := &command.InitCommand{
+		Meta: ops.Meta,
+	}
+
+	if e := i.Run(initArgs(p, cfg, dir)); e != 0 {
+		return checkUIErrors(ops.Ui)
+	}
+	return nil
+}
+
+// initArgs generates the flag list for the terraform init command based on the operator configuration
+func initArgs(p types.ProviderType, cfg map[string]interface{}, clusterDir string) []string {
+	args := make([]string, 0)
+
+	varsFile := filepath.Join(clusterDir, tfVarsFile)
+
+	args = append(args, fmt.Sprintf("-var-file=%s", varsFile), clusterDir)
+
+	return args
+}
+
+// tfApply runs a smart 'terraform apply' command with the specified options
+// and config in the given working directory.
+//
+// The smart logic is as follows:
+// - Apply is attempted regularly
+// - If failed with error "already exists" it means that the cluster exists but
+//   we do not have its state locally, so import the existing cluster and
+//   refresh the local state.
+// - if failed with error "not found" => probably state is corrupt => delete
+//   the state and start over with apply.
+func tfApply(ops Options, p types.ProviderType, cfg map[string]interface{}, dir string) error {
+	a := &command.ApplyCommand{
+		Meta: ops.Meta,
+	}
+	e := a.Run(applyArgs(p, cfg, dir))
+	if e != 0 {
+		errList := checkUIErrors(ops.Ui)
+
+		// if cluster already exists import it and refresh the state
+		if strings.Contains(strings.ToLower(errList.Error()), "already exists") {
+			i := &command.ImportCommand{
+				Meta: ops.Meta,
+			}
+
+			if e := i.Run(importArgs(p, cfg, dir)); e != 0 {
+				return checkUIErrors(ops.Ui)
+			}
+
+			r := &command.RefreshCommand{
+				Meta: ops.Meta,
+			}
+
+			if e := r.Run(refreshArgs(p, cfg, dir)); e != 0 {
+				return checkUIErrors(ops.Ui)
+			}
+			return nil
+		}
+
+		// if cluster was not found, cluster got deeted on the remote or state is wrong, delete state and start over
+		if strings.Contains(errList.Error(), "not found") {
+			// delete the corrupt state file
+			stateFile := filepath.Join(dir, tfStateFile)
+			if err := os.Remove(stateFile); err != nil {
+				return err
+			}
+
+			// try applying again
+			return tfApply(ops, p, cfg, dir)
+		}
+		return errList
+	}
+	return nil
+}
+
+// tfDestroy runs the 'terraform destroy' command with the specified options and config in the given working directory
+func tfDestroy(ops Options, p types.ProviderType, cfg map[string]interface{}, dir string) error {
+	a := &command.ApplyCommand{
+		Meta:    ops.Meta,
+		Destroy: true,
+	}
+	if e := a.Run(applyArgs(p, cfg, dir)); e != 0 {
+		return checkUIErrors(ops.Ui)
+	}
+	return nil
+}
+
+// applyArgs generates the flag list for the terraform apply command based on the operator configuration
+func applyArgs(p types.ProviderType, cfg map[string]interface{}, clusterDir string) []string {
+	args := make([]string, 0)
+
+	stateFile := filepath.Join(clusterDir, tfStateFile)
+	varsFile := filepath.Join(clusterDir, tfVarsFile)
+
+	args = append(args,
+		fmt.Sprintf("-state=%s", stateFile),
+		fmt.Sprintf("-var-file=%s", varsFile),
+		"-auto-approve",
+		clusterDir)
+
+	return args
+}
+
+// importArgs generates the flag list for the terraform import command based on the operator configuration
+func importArgs(p types.ProviderType, cfg map[string]interface{}, clusterDir string) []string {
+	args := make([]string, 0)
+
+	stateFile := filepath.Join(clusterDir, tfStateFile)
+	varsFile := filepath.Join(clusterDir, tfVarsFile)
+
+	args = append(args,
+		fmt.Sprintf("-state=%s", stateFile),
+		fmt.Sprintf("-state-out=%s", stateFile),
+		fmt.Sprintf("-var-file=%s", varsFile),
+		fmt.Sprintf("-config=%s", clusterDir),
+		clusterResource(p), // cluster resource
+		clusterID(p, cfg))  // cluster ID
+
+	return args
+}
+
+// clusterResource returns the cluster resource type defined in the terraform module for the given provider.
+func clusterResource(p types.ProviderType) string {
+	switch p {
+	case types.GCP:
+		return "google_container_cluster.gke_cluster"
+	case types.Azure:
+		return "azurerm_kubernetes_cluster.azure_cluster"
+	case types.Gardener:
+		return "gardener_shoot.gardener_cluster"
+	case types.AWS:
+		return "not supported"
+	}
+	return ""
+}
+
+// clusterID generates a cluster ID based on the given config.
+// Each provider has a different way of identifying clusters.
+func clusterID(p types.ProviderType, cfg map[string]interface{}) string {
+	switch p {
+	case types.GCP:
+		return fmt.Sprintf("%s/%s/%s", cfg["project"], cfg["location"], cfg["cluster_name"])
+	case types.Gardener:
+		return fmt.Sprintf("%s/%s", cfg["namespace"], cfg["cluster_name"])
+	case types.AWS:
+		return "not supported"
+	}
+	return ""
+}
+
+// refreshArgs generates the flag list for the terraform refresh command based on the operator configuration
+func refreshArgs(p types.ProviderType, cfg map[string]interface{}, clusterDir string) []string {
+	args := make([]string, 0)
+
+	stateFile := filepath.Join(clusterDir, tfStateFile)
+	varsFile := filepath.Join(clusterDir, tfVarsFile)
+
+	args = append(args,
+		fmt.Sprintf("-state=%s", stateFile),
+		fmt.Sprintf("-var-file=%s", varsFile),
+		clusterDir)
+
+	return args
+}
+
+func checkUIErrors(ui hashiCli.Ui) error {
+	var errsum strings.Builder
+	if h, ok := ui.(*HydroUI); ok {
+		for _, e := range h.Errors() {
+			if _, err := errsum.WriteString(e.Error()); err != nil {
+				return errors.Wrap(err, "could not fetch errors from terraform")
+			}
+		}
+	}
+
+	if errsum.Len() != 0 {
+		return errors.New(errsum.String())
+	}
+
+	return nil
+}

--- a/provision/internal/operator/terraform/tfcmd_test.go
+++ b/provision/internal/operator/terraform/tfcmd_test.go
@@ -1,0 +1,53 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/kyma-incubator/hydroform/provision/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitArgs(t *testing.T) {
+	// for now init args does not use the cluster and provider config for anything
+	res := initArgs("", nil, "/path/to/cluster")
+
+	require.Len(t, res, 2)
+	require.Equal(t, res[0], "-var-file=/path/to/cluster/terraform.tfvars") // vars file
+	require.Equal(t, res[1], "/path/to/cluster")                            // cluster config directory
+}
+
+func TestApplyArgs(t *testing.T) {
+	// for now apply args does not use the cluster and provider config for anything
+	res := applyArgs("", nil, "/path/to/cluster")
+
+	require.Len(t, res, 4)
+	require.Equal(t, res[0], "-state=/path/to/cluster/terraform.tfstate")   // state file
+	require.Equal(t, res[1], "-var-file=/path/to/cluster/terraform.tfvars") // vars file
+	require.Equal(t, res[2], "-auto-approve")                               // auto approve is important so that hydroform does not wait for user confirmation
+	require.Equal(t, res[3], "/path/to/cluster")                            // cluster config directory
+}
+
+func TestImportArgs(t *testing.T) {
+
+	cfg := map[string]interface{}{"project": "my-project", "namespace": "my-namespace", "location": "somewhere", "cluster_name": "my-cluster"}
+
+	// test GCP
+	res := importArgs(types.GCP, cfg, "/path/to/cluster")
+	require.Len(t, res, 6)
+	require.Equal(t, res[0], "-state=/path/to/cluster/terraform.tfstate")     // state file
+	require.Equal(t, res[1], "-state-out=/path/to/cluster/terraform.tfstate") // state output file
+	require.Equal(t, res[2], "-var-file=/path/to/cluster/terraform.tfvars")   // vars file
+	require.Equal(t, res[3], "-config=/path/to/cluster")                      // config folder for import to know where the tf files are (if any)
+	require.Equal(t, res[4], "google_container_cluster.gke_cluster")          // resource type for a GCP cluster
+	require.Equal(t, res[5], "my-project/somewhere/my-cluster")               // cluster ID
+
+	// test Gardener
+	res = importArgs(types.Gardener, cfg, "/path/to/cluster")
+	require.Len(t, res, 6)
+	require.Equal(t, res[0], "-state=/path/to/cluster/terraform.tfstate")     // state file
+	require.Equal(t, res[1], "-state-out=/path/to/cluster/terraform.tfstate") // state output file
+	require.Equal(t, res[2], "-var-file=/path/to/cluster/terraform.tfvars")   // vars file
+	require.Equal(t, res[3], "-config=/path/to/cluster")                      // config folder for import to know where the tf files are (if any)
+	require.Equal(t, res[4], "gardener_shoot.gardener_cluster")               // resource type for a GCP cluster
+	require.Equal(t, res[5], "my-namespace/my-cluster")                       // cluster ID
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Improved the `Provision` API call by making it more robust.
Calling provision on existing/lost/disconnected clusters will:
- Reattach to the ongoing apply operation
- Recover the lost state
- Refresh the state if out of sync.

**Related issue(s)**
#58 
