### PR TITLE
When cluster provision fails dont return nil

### DIFF
--- a/provision/internal/gardener/gardener.go
+++ b/provision/internal/gardener/gardener.go
@@ -48,7 +48,7 @@ func New(operatorType operator.Type, ops ...types.Option) *gardenerProvisioner {
 
 func (g *gardenerProvisioner) Provision(cluster *types.Cluster, provider *types.Provider) (*types.Cluster, error) {
 	if err := g.validate(cluster, provider); err != nil {
-		return nil, err
+		return cluster, err
 	}
 
 	config := g.loadConfigurations(cluster, provider)
@@ -208,12 +208,7 @@ func (g *gardenerProvisioner) validate(cluster *types.Cluster, provider *types.P
 	if _, ok := provider.CustomConfigurations["machine_image_version"]; !ok && targetProvider == string(types.Azure) {
 		errMessage += fmt.Sprintf(errs.CannotBeEmpty, "Provider.CustomConfigurations['machine_image_version']")
 	}
-	if _, ok := provider.CustomConfigurations["networks_azure_cidr"]; !ok && targetProvider == string(types.Azure) {
-		errMessage += fmt.Sprintf(errs.CannotBeEmpty, "Provider.CustomConfigurations['networks_azure_cidr']")
-	}
-	if _, ok := provider.CustomConfigurations["networks_azure_workers"]; !ok && targetProvider == string(types.Azure) {
-		errMessage += fmt.Sprintf(errs.CannotBeEmpty, "Provider.CustomConfigurations['networks_azure_workers']")
-	}
+
 	if _, ok := provider.CustomConfigurations["networking_nodes"]; !ok && targetProvider == string(types.Azure) {
 		errMessage += fmt.Sprintf(errs.CannotBeEmpty, "Provider.CustomConfigurations['networking_nodes']")
 	}

--- a/provision/internal/operator/terraform/files.go
+++ b/provision/internal/operator/terraform/files.go
@@ -184,8 +184,6 @@ variable "worker_minimum"			{}
 variable "worker_name"				{}
 variable "machine_image_name"		{}
 variable "machine_image_version"	{}
-variable "networks_azure_cidr"      {}
-variable "networks_azure_workers" 	{}
 
 
 provider "gardener" {
@@ -232,9 +230,9 @@ resource "gardener_shoot" "gardener_cluster" {
 			  azure {
                 networks {
                   vnet {
-					cidr = "${var.networks_azure_cidr}"          
+					cidr = "${var.vnetcidr}"
                   }
-				  workers = "${var.networks_azure_workers}" 
+				  workers = "${var.workercidr}"
                 }
               }
            {{ end }}


### PR DESCRIPTION
 - Dont return nil on cluster provision
 - Also re-use existing variables

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Return cluster struct even if cluster provision has failed.

Changes proposed in this pull request:

- Reuse existing variables.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
kyma-incubator/terraform-provider-gardener#34