### PR TITLE
in case of error on input validation return cluster

### DIFF
--- a/provision/internal/azure/azure.go
+++ b/provision/internal/azure/azure.go
@@ -23,7 +23,7 @@ type azureProvisioner struct {
 // Provision requests provisioning of a new Kubernetes cluster on Azure with the given configurations.
 func (a *azureProvisioner) Provision(cluster *types.Cluster, provider *types.Provider) (*types.Cluster, error) {
 	if err := a.validateInputs(cluster, provider); err != nil {
-		return nil, err
+		return cluster, err
 	}
 
 	config := a.loadConfigurations(cluster, provider)

--- a/provision/internal/gcp/gcp.go
+++ b/provision/internal/gcp/gcp.go
@@ -23,7 +23,7 @@ type gcpProvisioner struct {
 // Provision requests provisioning of a new Kubernetes cluster on GCP with the given configurations.
 func (g *gcpProvisioner) Provision(cluster *types.Cluster, provider *types.Provider) (*types.Cluster, error) {
 	if err := g.validateInputs(cluster, provider); err != nil {
-		return nil, err
+		return cluster, err
 	}
 
 	config := g.loadConfigurations(cluster, provider)


### PR DESCRIPTION
- We should return cluster instead of nil when we have errors on input validation

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

-  We should return cluster instead of nil when error.
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/cli/issues/389