### PR TITLE
Increase gardener provider download timeout

### DIFF
--- a/provision/internal/operator/terraform/gardener.go
+++ b/provision/internal/operator/terraform/gardener.go
@@ -104,7 +104,7 @@ func generateWindowsBinary(providerPath string) error {
 
 func downloadBinary(url string) (io.ReadCloser, error) {
 	c := &http.Client{
-		Timeout: 1 * time.Minute,
+		Timeout: 5 * time.Minute,
 	}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Increase the timeout for downloading the gardener provider binary in case of a slow connection
