### PR TITLE
Declare zoned only on azure

### DIFF
--- a/provision/internal/operator/terraform/files.go
+++ b/provision/internal/operator/terraform/files.go
@@ -104,7 +104,6 @@ variable "networking_services"		{
 }
 variable "networking_type"			{}
 variable "zones"      				{}
-variable "zoned"      				{}
 variable "workercidr"      			{
 	default = ""
 }
@@ -112,6 +111,7 @@ variable "workercidr"      			{
 variable "gcp_control_plane_zone"		{}
 {{ end }}
 {{ if eq (index . "target_provider") "azure" }}
+variable "zoned"      				{}
 variable "service_endpoints"		{}
 {{ end }}
 variable "machine_type"  			{}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Forgot to only declare the zones variable if we are on azure.

**Related issue(s)**
https://github.com/kyma-incubator/hydroform/issues/104
