### PR TITLE
Add prerequisites timeout to parallel install library

### DIFF
--- a/parallel-install/example/example.go
+++ b/parallel-install/example/example.go
@@ -56,8 +56,8 @@ func main() {
 
 	installationCfg := config.Config{
 		WorkersCount:                  4,
-		CancelTimeout:                 60 * time.Second,
-		QuitTimeout:                   1 * time.Second,
+		CancelTimeout:                 20 * time.Minute,
+		QuitTimeout:                   25 * time.Minute,
 		HelmTimeoutSeconds:            60 * 8,
 		BackoffInitialIntervalSeconds: 3,
 		BackoffMaxElapsedTimeSeconds:  60 * 5,
@@ -93,14 +93,14 @@ func main() {
 	engineCfg := engine.Config{WorkersCount: installer.Cfg.WorkersCount}
 	eng := engine.NewEngine(overridesProvider, componentsProvider, installer.ResourcesPath, engineCfg)
 
-	err = installer.StartKymaInstallation(prerequisitesProvider, overridesProvider, eng)
+	err = installer.StartKymaInstallation(kubeClient, prerequisitesProvider, overridesProvider, eng)
 	if err != nil {
 		log.Printf("Failed to install Kyma: %v", err)
 	} else {
 		log.Println("Kyma installed!")
 	}
 
-	err = installer.StartKymaUninstallation(prerequisitesProvider, overridesProvider, eng)
+	err = installer.StartKymaUninstallation(kubeClient, prerequisitesProvider, eng)
 	if err != nil {
 		log.Fatalf("Failed to uninstall Kyma: %v", err)
 	}

--- a/parallel-install/example/example.go
+++ b/parallel-install/example/example.go
@@ -8,9 +8,9 @@ import (
 	"io/ioutil"
 	"k8s.io/client-go/kubernetes"
 	"log"
-
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/config"
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/installation"
@@ -56,8 +56,8 @@ func main() {
 
 	installationCfg := config.Config{
 		WorkersCount:                  4,
-		CancelTimeoutSeconds:          60 * 20,
-		QuitTimeoutSeconds:            60 * 25,
+		CancelTimeout:                 60 * time.Second,
+		QuitTimeout:                   1 * time.Second,
 		HelmTimeoutSeconds:            60 * 8,
 		BackoffInitialIntervalSeconds: 3,
 		BackoffMaxElapsedTimeSeconds:  60 * 5,
@@ -77,12 +77,14 @@ func main() {
 
 	kubeClient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		//return fmt.Errorf("Unable to create internal client. Error: %v", err)
+		log.Printf("Failed to create kube client. Exiting...")
+		os.Exit(1)
 	}
 
 	overridesProvider, err := overrides.New(kubeClient, installer.OverridesYamls, installer.Cfg.Log)
 	if err != nil {
-		//return fmt.Errorf("Unable to create overrides provider. Error: %v", err)
+		log.Printf("Failed to create overrides provider. Exiting...")
+		os.Exit(1)
 	}
 
 	prerequisitesProvider := components.NewPrerequisitesProvider(overridesProvider, installer.ResourcesPath, installer.Prerequisites, installer.Cfg)

--- a/parallel-install/example/example.go
+++ b/parallel-install/example/example.go
@@ -91,14 +91,14 @@ func main() {
 	engineCfg := engine.Config{WorkersCount: installer.Cfg.WorkersCount}
 	eng := engine.NewEngine(overridesProvider, componentsProvider, installer.ResourcesPath, engineCfg)
 
-	err = installer.StartKymaInstallation(*prerequisitesProvider, overridesProvider, eng)
+	err = installer.StartKymaInstallation(prerequisitesProvider, overridesProvider, eng)
 	if err != nil {
 		log.Printf("Failed to install Kyma: %v", err)
 	} else {
 		log.Println("Kyma installed!")
 	}
 
-	err = installer.StartKymaUninstallation(*prerequisitesProvider, overridesProvider, eng)
+	err = installer.StartKymaUninstallation(prerequisitesProvider, overridesProvider, eng)
 	if err != nil {
 		log.Fatalf("Failed to uninstall Kyma: %v", err)
 	}

--- a/parallel-install/example/example.go
+++ b/parallel-install/example/example.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"flag"
-	"github.com/kyma-incubator/hydroform/parallel-install/pkg/components"
-	"github.com/kyma-incubator/hydroform/parallel-install/pkg/engine"
-	"github.com/kyma-incubator/hydroform/parallel-install/pkg/overrides"
 	"io/ioutil"
 	"k8s.io/client-go/kubernetes"
 	"log"
@@ -81,26 +78,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	overridesProvider, err := overrides.New(kubeClient, installer.OverridesYamls, installer.Cfg.Log)
-	if err != nil {
-		log.Printf("Failed to create overrides provider. Exiting...")
-		os.Exit(1)
-	}
-
-	prerequisitesProvider := components.NewPrerequisitesProvider(overridesProvider, installer.ResourcesPath, installer.Prerequisites, installer.Cfg)
-	componentsProvider := components.NewComponentsProvider(overridesProvider, installer.ResourcesPath, installer.ComponentsYaml, installer.Cfg)
-
-	engineCfg := engine.Config{WorkersCount: installer.Cfg.WorkersCount}
-	eng := engine.NewEngine(overridesProvider, componentsProvider, installer.ResourcesPath, engineCfg)
-
-	err = installer.StartKymaInstallation(kubeClient, prerequisitesProvider, overridesProvider, eng)
+	err = installer.StartKymaInstallation(kubeClient)
 	if err != nil {
 		log.Printf("Failed to install Kyma: %v", err)
 	} else {
 		log.Println("Kyma installed!")
 	}
 
-	err = installer.StartKymaUninstallation(kubeClient, prerequisitesProvider, eng)
+	err = installer.StartKymaUninstallation(kubeClient)
 	if err != nil {
 		log.Fatalf("Failed to uninstall Kyma: %v", err)
 	}

--- a/parallel-install/pkg/config/config.go
+++ b/parallel-install/pkg/config/config.go
@@ -1,6 +1,9 @@
 package config
 
-import "log"
+import (
+	"log"
+	"time"
+)
 
 //Configures various install/uninstall operation parameters.
 //There are no different parameters for Install/Delete operations - if you need it to be different, just use two Installations with two different configs.
@@ -8,11 +11,11 @@ type Config struct {
 	//Number of concurrent workers used for an install/delete operation.
 	WorkersCount int
 	//After this time workers' context is canceled. Pending worker goroutines (if any) may continue if blocked by Helm client.
-	CancelTimeoutSeconds int
+	CancelTimeout time.Duration
 	//After this time install/delete operation is aborted and returns an error to the user.
 	//Worker goroutines may still be working in the background.
-	//Must be greater than CancelTimeoutSeconds.
-	QuitTimeoutSeconds int
+	//Must be greater than CancelTimeout.
+	QuitTimeout time.Duration
 	//Timeout for Helm client
 	HelmTimeoutSeconds int
 	//Initial interval used for exponent backoff retry policy

--- a/parallel-install/pkg/installation/installation.go
+++ b/parallel-install/pkg/installation/installation.go
@@ -52,19 +52,19 @@ func NewInstallation(prerequisites [][]string, componentsYaml string, overridesY
 }
 
 func (i *Installation) StartKymaInstallation(kubeClient kubernetes.Interface) error {
-	overridesProvider, prerequisitesProvider, eng, err := i.getConfig(kubeClient)
+	overridesProvider, prerequisitesProvider, engine, err := i.getConfig(kubeClient)
 	if err != nil {
 		return err
 	}
-	return i.startKymaInstallation(kubeClient, prerequisitesProvider, overridesProvider, eng)
+	return i.startKymaInstallation(kubeClient, prerequisitesProvider, overridesProvider, engine)
 }
 
 func (i *Installation) StartKymaUninstallation(kubeClient kubernetes.Interface) error {
-	_, prerequisitesProvider, eng, err := i.getConfig(kubeClient)
+	_, prerequisitesProvider, engine, err := i.getConfig(kubeClient)
 	if err != nil {
 		return err
 	}
-	return i.startKymaUninstallation(kubeClient, prerequisitesProvider, eng)
+	return i.startKymaUninstallation(kubeClient, prerequisitesProvider, engine)
 }
 
 func (i *Installation) startKymaInstallation(kubeClient kubernetes.Interface, prerequisitesProvider components.Provider, overridesProvider overrides.OverridesProvider, eng *engine.Engine) error {

--- a/parallel-install/pkg/installation/installation.go
+++ b/parallel-install/pkg/installation/installation.go
@@ -51,7 +51,7 @@ func NewInstallation(prerequisites [][]string, componentsYaml string, overridesY
 	}, nil
 }
 
-func (i *Installation) StartKymaInstallation(kubeClient *kubernetes.Clientset, prerequisitesProvider components.Provider, overridesProvider overrides.OverridesProvider, eng *engine.Engine) error {
+func (i *Installation) StartKymaInstallation(kubeClient kubernetes.Interface, prerequisitesProvider components.Provider, overridesProvider overrides.OverridesProvider, eng *engine.Engine) error {
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -89,7 +89,7 @@ func (i *Installation) StartKymaInstallation(kubeClient *kubernetes.Clientset, p
 	return nil
 }
 
-func (i *Installation) StartKymaUninstallation(kubeClient *kubernetes.Clientset, prerequisitesProvider components.Provider, eng *engine.Engine) error {
+func (i *Installation) StartKymaUninstallation(kubeClient kubernetes.Interface, prerequisitesProvider components.Provider, eng *engine.Engine) error {
 	i.Cfg.Log("Kyma uninstallation started")
 
 	cancelCtx, cancel := context.WithCancel(context.Background())
@@ -130,7 +130,7 @@ func (i *Installation) logStatuses(statusMap map[string]string) {
 	}
 }
 
-func (i *Installation) installPrerequisites(ctx context.Context, cancelFunc context.CancelFunc, kubeClient *kubernetes.Clientset, p []components.Component, cancelTimeout time.Duration, quitTimeout time.Duration) error {
+func (i *Installation) installPrerequisites(ctx context.Context, cancelFunc context.CancelFunc, kubeClient kubernetes.Interface, p []components.Component, cancelTimeout time.Duration, quitTimeout time.Duration) error {
 
 	cancelTimeoutChan := time.After(cancelTimeout)
 	quitTimeoutChan := time.After(quitTimeout)
@@ -144,7 +144,7 @@ Prerequisites:
 		case prerequisiteErr, ok := <-prereqStatusChan:
 			if ok {
 				if prerequisiteErr != nil {
-					return fmt.Errorf("Kyma installation failed due to an error. Look at the preceeding logs to find out more")
+					return fmt.Errorf("Kyma installation failed due to an error: %s", prerequisiteErr)
 				}
 			} else {
 				if timeoutOccurred {
@@ -164,7 +164,7 @@ Prerequisites:
 	return nil
 }
 
-func (i *Installation) uninstallPrerequisites(ctx context.Context, cancelFunc context.CancelFunc, kubeClient *kubernetes.Clientset, p []components.Component, cancelTimeout time.Duration, quitTimeout time.Duration) error {
+func (i *Installation) uninstallPrerequisites(ctx context.Context, cancelFunc context.CancelFunc, kubeClient kubernetes.Interface, p []components.Component, cancelTimeout time.Duration, quitTimeout time.Duration) error {
 
 	cancelTimeoutChan := time.After(cancelTimeout)
 	quitTimeoutChan := time.After(quitTimeout)

--- a/parallel-install/pkg/installation/installation.go
+++ b/parallel-install/pkg/installation/installation.go
@@ -254,6 +254,8 @@ func (i *Installation) installComponents(ctx context.Context, cancelFunc context
 }
 
 func (i *Installation) uninstallComponents(ctx context.Context, cancelFunc context.CancelFunc, eng *engine.Engine, cancelTimeout time.Duration, quitTimeout time.Duration) error {
+	cancelTimeoutChan := time.After(cancelTimeout)
+	quitTimeoutChan := time.After(quitTimeout)
 	var statusMap = map[string]string{}
 	var errCount int = 0
 	var timeoutOccured bool = false
@@ -283,11 +285,11 @@ Loop:
 				}
 				break Loop
 			}
-		case <-time.After(cancelTimeout):
+		case <-cancelTimeoutChan:
 			timeoutOccured = true
 			i.Cfg.Log("Timeout occurred after %v minutes. Cancelling uninstallation", cancelTimeout.Minutes())
 			cancelFunc()
-		case <-time.After(quitTimeout):
+		case <-quitTimeoutChan:
 			i.Cfg.Log("Uninstallation doesn't stop after it's canceled. Enforcing quit")
 			return fmt.Errorf("Force quit: Kyma uninstallation failed due to the timeout")
 		}

--- a/parallel-install/pkg/installation/installation.go
+++ b/parallel-install/pkg/installation/installation.go
@@ -208,7 +208,6 @@ Prerequisites:
 	return nil
 }
 
-
 func (i *Installation) installComponents(ctx context.Context, cancelFunc context.CancelFunc, eng *engine.Engine, cancelTimeout time.Duration, quitTimeout time.Duration) error {
 	cancelTimeoutChan := time.After(cancelTimeout)
 	quitTimeoutChan := time.After(quitTimeout)
@@ -298,5 +297,5 @@ Loop:
 
 func calculateDuration(start time.Time, end time.Time, duration int) time.Duration {
 	elapsedTime := end.Sub(start)
-	return time.Duration(duration) * time.Second - elapsedTime
+	return time.Duration(duration)*time.Second - elapsedTime
 }

--- a/parallel-install/pkg/installation/installation.go
+++ b/parallel-install/pkg/installation/installation.go
@@ -28,10 +28,10 @@ type Installation struct {
 type Installer interface {
 	//This method will block until installation is finished or an error or timeout occurs.
 	//If the installation is not finished in configured config.Config.QuitTimeout, the method returns with an error. Some worker goroutines may still be active.
-	StartKymaInstallation(prerequisitesProvider components.Provider, overridesProvider overrides.OverridesProvider, eng *engine.Engine) error
+	StartKymaInstallation(kubeClient kubernetes.Interface, prerequisitesProvider components.Provider, overridesProvider overrides.OverridesProvider, eng *engine.Engine) error
 	//This method will block until uninstallation is finished or an error or timeout occurs.
 	//If the uninstallation is not finished in configured config.Config.QuitTimeout, the method returns with an error. Some worker goroutines may still be active.
-	StartKymaUninstallation(prerequisitesProvider components.Provider, overridesProvider overrides.OverridesProvider, eng *engine.Engine) error
+	StartKymaUninstallation(kubeClient kubernetes.Interface, prerequisitesProvider components.Provider, eng *engine.Engine) error
 }
 
 func NewInstallation(prerequisites [][]string, componentsYaml string, overridesYamls []string, resourcesPath string, cfg config.Config) (*Installation, error) {

--- a/parallel-install/pkg/installation/installation_test.go
+++ b/parallel-install/pkg/installation/installation_test.go
@@ -1,0 +1,1 @@
+package installation

--- a/parallel-install/pkg/installation/installation_test.go
+++ b/parallel-install/pkg/installation/installation_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/config"
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/engine"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes/fake"
+
 	//"k8s.io/client-go/kubernetes/fake"
 	"log"
 	"testing"
@@ -22,6 +24,8 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 	i := newInstallation()
 
 	t.Run("should install Kyma", func(t *testing.T) {
+		kubeClient := fake.NewSimpleClientset()
+
 		hc := &mockHelmClient{}
 		provider := &mockProvider{
 			hc: hc,
@@ -32,13 +36,15 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 			Log:          log.Printf,
 		})
 
-		err := i.StartKymaInstallation(provider, overridesProvider, eng)
+		err := i.StartKymaInstallation(kubeClient, provider, overridesProvider, eng)
 
 		assert.NoError(t, err)
 	})
 
 	t.Run("should fail to install Kyma prerequisites", func(t *testing.T) {
 		t.Run("due to cancel timeout", func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset()
+
 			hc := &mockHelmClient{
 				componentProcessingTime: 200,
 			}
@@ -51,12 +57,14 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 				Log:          log.Printf,
 			})
 
-			err := i.StartKymaInstallation(provider, overridesProvider, eng)
+			err := i.StartKymaInstallation(kubeClient, provider, overridesProvider, eng)
 
 			assert.Error(t, err)
 			assert.EqualError(t, err, "Kyma prerequisites installation failed due to the timeout")
 		})
 		t.Run("due to quit timeout", func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset()
+
 			hc := &mockHelmClient{
 				componentProcessingTime: 300,
 			}
@@ -70,7 +78,7 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 			})
 
 			start := time.Now()
-			err := i.StartKymaInstallation(provider, overridesProvider, eng)
+			err := i.StartKymaInstallation(kubeClient, provider, overridesProvider, eng)
 			end := time.Now()
 
 			elapsed := end.Sub(start)
@@ -88,6 +96,8 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 
 	t.Run("should install prerequisites and fail to install Kyma components", func(t *testing.T) {
 		t.Run("due to cancel timeout", func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset()
+
 			hc := &mockHelmClient{
 				componentProcessingTime: 40,
 			}
@@ -100,12 +110,13 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 				Log:          log.Printf,
 			})
 
-			err := i.StartKymaInstallation(provider, overridesProvider, eng)
+			err := i.StartKymaInstallation(kubeClient, provider, overridesProvider, eng)
 
 			assert.Error(t, err)
 			assert.EqualError(t, err, "Kyma installation failed due to the timeout")
 		})
 		t.Run("due to quit timeout", func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset()
 
 			inst := newInstallation()
 
@@ -125,7 +136,7 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 			})
 
 			start := time.Now()
-			err := inst.StartKymaInstallation(provider, overridesProvider, eng)
+			err := inst.StartKymaInstallation(kubeClient, provider, overridesProvider, eng)
 			end := time.Now()
 
 			elapsed := end.Sub(start)
@@ -147,6 +158,8 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 	i := newInstallation()
 
 	t.Run("should uninstall Kyma", func(t *testing.T) {
+		kubeClient := fake.NewSimpleClientset()
+
 		hc := &mockHelmClient{}
 		provider := &mockProvider{
 			hc: hc,
@@ -157,13 +170,15 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 			Log:          log.Printf,
 		})
 
-		err := i.StartKymaUninstallation(provider, overridesProvider, eng)
+		err := i.StartKymaUninstallation(kubeClient, provider, eng)
 
 		assert.NoError(t, err)
 	})
 
 	t.Run("should fail to uninstall Kyma components", func(t *testing.T) {
 		t.Run("due to cancel timeout", func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset()
+
 			hc := &mockHelmClient{
 				componentProcessingTime: 200,
 			}
@@ -176,12 +191,14 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 				Log:          log.Printf,
 			})
 
-			err := i.StartKymaUninstallation(provider, overridesProvider, eng)
+			err := i.StartKymaUninstallation(kubeClient, provider, eng)
 
 			assert.Error(t, err)
 			assert.EqualError(t, err, "Kyma uninstallation failed due to the timeout")
 		})
 		t.Run("due to quit timeout", func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset()
+
 			hc := &mockHelmClient{
 				componentProcessingTime: 300,
 			}
@@ -195,7 +212,7 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 			})
 
 			start := time.Now()
-			err := i.StartKymaUninstallation(provider, overridesProvider, eng)
+			err := i.StartKymaUninstallation(kubeClient, provider, eng)
 			end := time.Now()
 
 			elapsed := end.Sub(start)
@@ -215,6 +232,8 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 
 	t.Run("should uninstall components and fail to install Kyma prerequisites", func(t *testing.T) {
 		t.Run("due to cancel timeout", func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset()
+
 			hc := &mockHelmClient{
 				componentProcessingTime: 40,
 			}
@@ -227,12 +246,13 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 				Log:          log.Printf,
 			})
 
-			err := i.StartKymaUninstallation(provider, overridesProvider, eng)
+			err := i.StartKymaUninstallation(kubeClient, provider, eng)
 
 			assert.Error(t, err)
 			assert.EqualError(t, err, "Kyma prerequisites uninstallation failed due to the timeout")
 		})
 		t.Run("due to quit timeout", func(t *testing.T) {
+			kubeClient := fake.NewSimpleClientset()
 
 			inst := newInstallation()
 
@@ -252,7 +272,7 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 			})
 
 			start := time.Now()
-			err := inst.StartKymaUninstallation(provider, overridesProvider, eng)
+			err := inst.StartKymaUninstallation(kubeClient, provider, eng)
 			end := time.Now()
 
 			elapsed := end.Sub(start)
@@ -268,7 +288,6 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 		})
 	})
 }
-
 
 type mockHelmClient struct {
 	componentProcessingTime int
@@ -297,7 +316,7 @@ func newInstallation() Installation {
 }
 
 type mockProvider struct {
-	hc	*mockHelmClient
+	hc *mockHelmClient
 }
 
 func (p *mockProvider) GetComponents() ([]components.Component, error) {
@@ -326,7 +345,7 @@ func (p *mockProvider) GetComponents() ([]components.Component, error) {
 	}, nil
 }
 
-type mockOverridesProvider struct {}
+type mockOverridesProvider struct{}
 
 func (o *mockOverridesProvider) OverridesGetterFunctionFor(name string) func() map[string]interface{} {
 	return nil

--- a/parallel-install/pkg/installation/installation_test.go
+++ b/parallel-install/pkg/installation/installation_test.go
@@ -1,1 +1,93 @@
 package installation
+
+import (
+	"context"
+	"fmt"
+	"github.com/kyma-incubator/hydroform/parallel-install/pkg/components"
+	"github.com/kyma-incubator/hydroform/parallel-install/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"testing"
+	"time"
+)
+
+const cancelTimeout = 50
+const quitTimeout = 150
+const cancelTimeoutMillisecond = time.Duration(50) * time.Millisecond
+const quitTimeoutMillisecond = time.Duration(150) * time.Millisecond
+
+
+func Test_CancelTimeout(t *testing.T) {
+	//given
+	i := newInstallation()
+
+	ctx, cancelFunc := context.WithCancel(context.TODO())
+
+	hc := &mockHelmClient{
+		cancelWithTimeout: true,
+	}
+	component := newComponent(hc)
+
+	//when
+	err := i.installPrerequisites(ctx, cancelFunc, []components.Component{component}, cancelTimeoutMillisecond, quitTimeoutMillisecond)
+
+	//then
+	assert.Error(t, err, "Kyma installation failed due to the timeout")
+}
+
+func Test_QuitTimeout(t *testing.T) {
+	//given
+	i := newInstallation()
+
+	ctx, cancelFunc := context.WithCancel(context.TODO())
+
+	hc := &mockHelmClient{
+		quitWithTimeout: true,
+	}
+	component := newComponent(hc)
+
+	//when
+	err := i.installPrerequisites(ctx, cancelFunc, []components.Component{component}, cancelTimeoutMillisecond, quitTimeoutMillisecond)
+
+	fmt.Println(err)
+	//then
+	assert.Error(t, err, "Kyma installation failed due to the timeout")
+}
+
+type mockHelmClient struct {
+	cancelWithTimeout bool
+	quitWithTimeout bool
+}
+
+func (c *mockHelmClient) InstallRelease(chartDir, namespace, name string, overrides map[string]interface{}) error {
+	if c.cancelWithTimeout {
+		time.Sleep(100 * time.Millisecond)
+	}
+	if c.quitWithTimeout{
+		time.Sleep(200 * time.Millisecond)
+	}
+	return nil
+}
+func (c *mockHelmClient) UninstallRelease(namespace, name string) error {
+	return nil
+}
+
+func newInstallation() Installation {
+	return Installation{
+		Cfg:            config.Config{
+			CancelTimeoutSeconds:          cancelTimeout,
+			QuitTimeoutSeconds:            quitTimeout,
+			Log:                           log.Printf,
+		},
+	}
+}
+
+func newComponent(hc *mockHelmClient) components.Component {
+	return components.Component{
+		Name:            "test",
+		Namespace:       "test",
+		OverridesGetter: func() map[string]interface{} { return nil },
+		HelmClient:      hc,
+		Log:             log.Printf,
+	}
+}

--- a/parallel-install/pkg/installation/installation_test.go
+++ b/parallel-install/pkg/installation/installation_test.go
@@ -120,10 +120,10 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 			inst := newInstallation()
 
 			// Changing it to higher amount to minimize difference between cancel and quit timeout
-			inst.Cfg.CancelTimeout = 200 * time.Millisecond
+			inst.Cfg.CancelTimeout = 220 * time.Millisecond
 
 			hc := &mockHelmClient{
-				componentProcessingTime: 60,
+				componentProcessingTime: 70,
 			}
 			provider := &mockProvider{
 				hc: hc,
@@ -254,10 +254,10 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 			inst := newInstallation()
 
 			// Changing it to higher amount to minimize difference between cancel and quit timeout
-			inst.Cfg.CancelTimeout = 200 * time.Millisecond
+			inst.Cfg.CancelTimeout = 220 * time.Millisecond
 
 			hc := &mockHelmClient{
-				componentProcessingTime: 60,
+				componentProcessingTime: 70,
 			}
 			provider := &mockProvider{
 				hc: hc,

--- a/parallel-install/pkg/installation/installation_test.go
+++ b/parallel-install/pkg/installation/installation_test.go
@@ -2,7 +2,6 @@ package installation
 
 import (
 	"context"
-	"fmt"
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/components"
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/config"
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/engine"
@@ -86,7 +85,7 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 			assert.Error(t, err)
 			assert.EqualError(t, err, "Force quit: Kyma prerequisites installation failed due to the timeout")
 
-			// One component installation lasts 280 ms
+			// One component installation lasts 300 ms
 			// Quit timeout occurs at 250 ms
 			// Check if program quits in the meantime
 			assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(250))
@@ -216,8 +215,6 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 			end := time.Now()
 
 			elapsed := end.Sub(start)
-
-			fmt.Printf("TIME: %d", elapsed.Milliseconds())
 
 			assert.Error(t, err)
 			assert.EqualError(t, err, "Force quit: Kyma uninstallation failed due to the timeout")

--- a/parallel-install/pkg/installation/installation_test.go
+++ b/parallel-install/pkg/installation/installation_test.go
@@ -12,19 +12,15 @@ import (
 	"time"
 )
 
-
 const cancelTimeout = 100
 const quitTimeout = 150
 const cancelTimeoutMillisecond = time.Duration(50) * time.Millisecond
 const quitTimeoutMillisecond = time.Duration(150) * time.Millisecond
 
-
 func Test_installPrerequisites(t *testing.T) {
 	i := newInstallation()
 
-
-
-	t.Run("should install prerequisites with no error", func (t *testing.T) {
+	t.Run("should install prerequisites with no error", func(t *testing.T) {
 		ctx, cancelFunc := context.WithCancel(context.TODO())
 		defer cancelFunc()
 
@@ -38,7 +34,7 @@ func Test_installPrerequisites(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("should cancel installation after given timeout and exit with error", func (t *testing.T){
+	t.Run("should cancel installation after given timeout and exit with error", func(t *testing.T) {
 		ctx, cancelFunc := context.WithCancel(context.TODO())
 		defer cancelFunc()
 
@@ -55,7 +51,7 @@ func Test_installPrerequisites(t *testing.T) {
 		assert.EqualError(t, err, "Kyma installation failed due to the timeout")
 	})
 
-	t.Run("should quit installation after given timeout and exit with error", func (t *testing.T) {
+	t.Run("should quit installation after given timeout and exit with error", func(t *testing.T) {
 		ctx, cancelFunc := context.WithCancel(context.TODO())
 		defer cancelFunc()
 
@@ -72,7 +68,7 @@ func Test_installPrerequisites(t *testing.T) {
 		assert.EqualError(t, err, "Force quit: Kyma installation failed due to the timeout")
 	})
 
-	t.Run("should not install next components after timeout", func (t *testing.T) {
+	t.Run("should not install next components after timeout", func(t *testing.T) {
 		ctx, cancelFunc := context.WithCancel(context.TODO())
 		defer cancelFunc()
 
@@ -101,8 +97,8 @@ func Test_installPrerequisites(t *testing.T) {
 }
 
 type mockHelmClient struct {
-	cancelWithTimeout bool
-	quitWithTimeout bool
+	cancelWithTimeout         bool
+	quitWithTimeout           bool
 	cancelAfterFirstComponent bool
 }
 
@@ -110,7 +106,7 @@ func (c *mockHelmClient) InstallRelease(ctx context.Context, chartDir, namespace
 	if c.cancelWithTimeout {
 		time.Sleep(120 * time.Millisecond)
 	}
-	if c.quitWithTimeout{
+	if c.quitWithTimeout {
 		time.Sleep(500 * time.Millisecond)
 	}
 	if c.cancelAfterFirstComponent {
@@ -125,10 +121,10 @@ func (c *mockHelmClient) UninstallRelease(ctx context.Context, namespace, name s
 func newInstallation() Installation {
 	return Installation{
 
-		Cfg:            config.Config{
-			CancelTimeoutSeconds:          cancelTimeout,
-			QuitTimeoutSeconds:            quitTimeout,
-			Log:                           log.Printf,
+		Cfg: config.Config{
+			CancelTimeoutSeconds: cancelTimeout,
+			QuitTimeoutSeconds:   quitTimeout,
+			Log:                  log.Printf,
 		},
 	}
 }

--- a/parallel-install/pkg/installation/installation_test.go
+++ b/parallel-install/pkg/installation/installation_test.go
@@ -183,7 +183,7 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 		})
 		t.Run("due to quit timeout", func(t *testing.T) {
 			hc := &mockHelmClient{
-				componentProcessingTime: 320,
+				componentProcessingTime: 300,
 			}
 			provider := &mockProvider{
 				hc: hc,
@@ -209,7 +209,7 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 			// Quit timeout occurs at 250 ms
 			// Check if program quits in the meantime
 			assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(250))
-			assert.Less(t, elapsed.Milliseconds(), int64(320))
+			assert.Less(t, elapsed.Milliseconds(), int64(300))
 		})
 	})
 

--- a/parallel-install/pkg/installation/installation_test.go
+++ b/parallel-install/pkg/installation/installation_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/components"
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/config"
+	"github.com/kyma-incubator/hydroform/parallel-install/pkg/engine"
 	"github.com/stretchr/testify/assert"
 	//"k8s.io/client-go/kubernetes/fake"
 	"log"
@@ -12,89 +13,167 @@ import (
 	"time"
 )
 
-const cancelTimeout = 100
-const quitTimeout = 150
+const cancelTimeout = 1
+const quitTimeout = 2
 const cancelTimeoutMillisecond = time.Duration(50) * time.Millisecond
 const quitTimeoutMillisecond = time.Duration(150) * time.Millisecond
 
-func Test_installPrerequisites(t *testing.T) {
+func TestInstallation_StartKymaInstallation(t *testing.T) {
+	t.Parallel()
 	i := newInstallation()
 
-	t.Run("should install prerequisites with no error", func(t *testing.T) {
-		ctx, cancelFunc := context.WithCancel(context.TODO())
-		defer cancelFunc()
-
+	t.Run("should install Kyma", func(t *testing.T) {
 		hc := &mockHelmClient{}
-		comps := newComponents(hc)
+		provider := &mockProvider{
+			hc: hc,
+		}
+		overridesProvider := &mockOverridesProvider{}
+		eng := engine.NewEngine(overridesProvider, provider, "", engine.Config{
+			WorkersCount: 2,
+			Log:          log.Printf,
+		})
 
-		//when
-		err := i.installPrerequisites(ctx, cancelFunc, comps, cancelTimeoutMillisecond, quitTimeoutMillisecond)
+		err := i.StartKymaInstallation(provider, overridesProvider, eng)
 
-		//then
 		assert.NoError(t, err)
 	})
 
-	t.Run("should cancel installation after given timeout and exit with error", func(t *testing.T) {
-		ctx, cancelFunc := context.WithCancel(context.TODO())
-		defer cancelFunc()
-
+	t.Run("should fail to install Kyma prerequisites due to cancel timeout", func(t *testing.T) {
 		hc := &mockHelmClient{
 			cancelWithTimeout: true,
 		}
-		comps := newComponents(hc)
+		provider := &mockProvider{
+			hc: hc,
+		}
+		overridesProvider := &mockOverridesProvider{}
+		eng := engine.NewEngine(overridesProvider, provider, "", engine.Config{
+			WorkersCount: 1,
+			Log:          log.Printf,
+		})
 
-		//when
-		err := i.installPrerequisites(ctx, cancelFunc, comps, cancelTimeoutMillisecond, quitTimeoutMillisecond)
+		err := i.StartKymaInstallation(provider, overridesProvider, eng)
 
-		//then
 		assert.Error(t, err)
-		assert.EqualError(t, err, "Kyma installation failed due to the timeout")
+		assert.EqualError(t, err, "Kyma prerequisites installation failed due to the timeout")
 	})
 
-	t.Run("should quit installation after given timeout and exit with error", func(t *testing.T) {
-		ctx, cancelFunc := context.WithCancel(context.TODO())
-		defer cancelFunc()
-
+	t.Run("should fail to install Kyma prerequisites due to quit timeout", func(t *testing.T) {
 		hc := &mockHelmClient{
 			quitWithTimeout: true,
 		}
-		comps := newComponents(hc)
+		provider := &mockProvider{
+			hc: hc,
+		}
+		overridesProvider := &mockOverridesProvider{}
+		eng := engine.NewEngine(overridesProvider, provider, "", engine.Config{
+			WorkersCount: 1,
+			Log:          log.Printf,
+		})
 
-		//when
-		err := i.installPrerequisites(ctx, cancelFunc, comps, cancelTimeoutMillisecond, quitTimeoutMillisecond)
+		err := i.StartKymaInstallation(provider, overridesProvider, eng)
 
-		//then
 		assert.Error(t, err)
-		assert.EqualError(t, err, "Force quit: Kyma installation failed due to the timeout")
+		assert.EqualError(t, err, "Force quit: Kyma prerequisites installation failed due to the timeout")
 	})
 
-	t.Run("should not install next components after timeout", func(t *testing.T) {
-		ctx, cancelFunc := context.WithCancel(context.TODO())
-		defer cancelFunc()
-
+	t.Run("should install prerequisites and fail to install Kyma components due to timeout", func(t *testing.T) {
 		hc := &mockHelmClient{
 			cancelAfterFirstComponent: true,
 		}
-		comps := newComponents(hc)
+		provider := &mockProvider{
+			hc: hc,
+		}
+		overridesProvider := &mockOverridesProvider{}
+		eng := engine.NewEngine(overridesProvider, provider, "", engine.Config{
+			WorkersCount: 1,
+			Log:          log.Printf,
+		})
 
-		//when
-		startTime := time.Now()
-		err := i.installPrerequisites(ctx, cancelFunc, comps, cancelTimeoutMillisecond, quitTimeoutMillisecond)
-		endTime := time.Now()
+		err := i.StartKymaInstallation(provider, overridesProvider, eng)
 
-		elapsed := endTime.Sub(startTime)
+		fmt.Println(err)
 
-		fmt.Printf("%d", elapsed.Milliseconds())
-
-		//then
 		assert.Error(t, err)
-		// One component installation takes 80 ms
-		// So to install one component this assertion must be true
-		// 80 <= componentInstallationTime < 160
-		assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(80))
-		assert.Less(t, elapsed.Milliseconds(), int64(160))
+		assert.EqualError(t, err, "Kyma installation failed due to the timeout")
 	})
 }
+
+//func Test_installPrerequisites(t *testing.T) {
+//	i := newInstallation()
+//
+//	t.Run("should install prerequisites with no error", func(t *testing.T) {
+//		ctx, cancelFunc := context.WithCancel(context.TODO())
+//		defer cancelFunc()
+//
+//		hc := &mockHelmClient{}
+//		comps := newComponents(hc)
+//
+//		//when
+//		err := i.installPrerequisites(ctx, cancelFunc, comps, cancelTimeoutMillisecond, quitTimeoutMillisecond)
+//
+//		//then
+//		assert.NoError(t, err)
+//	})
+//
+//	t.Run("should cancel installation after given timeout and exit with error", func(t *testing.T) {
+//		ctx, cancelFunc := context.WithCancel(context.TODO())
+//		defer cancelFunc()
+//
+//		hc := &mockHelmClient{
+//			cancelWithTimeout: true,
+//		}
+//		comps := newComponents(hc)
+//
+//		//when
+//		err := i.installPrerequisites(ctx, cancelFunc, comps, cancelTimeoutMillisecond, quitTimeoutMillisecond)
+//
+//		//then
+//		assert.Error(t, err)
+//		assert.EqualError(t, err, "Kyma installation failed due to the timeout")
+//	})
+//
+//	t.Run("should quit installation after given timeout and exit with error", func(t *testing.T) {
+//		ctx, cancelFunc := context.WithCancel(context.TODO())
+//		defer cancelFunc()
+//
+//		hc := &mockHelmClient{
+//			quitWithTimeout: true,
+//		}
+//		comps := newComponents(hc)
+//
+//		//when
+//		err := i.installPrerequisites(ctx, cancelFunc, comps, cancelTimeoutMillisecond, quitTimeoutMillisecond)
+//
+//		//then
+//		assert.Error(t, err)
+//		assert.EqualError(t, err, "Force quit: Kyma installation failed due to the timeout")
+//	})
+//
+//	t.Run("should not install next components after timeout", func(t *testing.T) {
+//		ctx, cancelFunc := context.WithCancel(context.TODO())
+//		defer cancelFunc()
+//
+//		hc := &mockHelmClient{
+//			cancelAfterFirstComponent: true,
+//		}
+//		comps := newComponents(hc)
+//
+//		//when
+//		startTime := time.Now()
+//		err := i.installPrerequisites(ctx, cancelFunc, comps, cancelTimeoutMillisecond, quitTimeoutMillisecond)
+//		endTime := time.Now()
+//
+//		elapsed := endTime.Sub(startTime)
+//
+//		//then
+//		assert.Error(t, err)
+//		// One component installation takes 80 ms
+//		// So to install one component this assertion must be true
+//		// 80 <= componentInstallationTime < 160
+//		assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(80))
+//		assert.Less(t, elapsed.Milliseconds(), int64(160))
+//	})
+//}
 
 type mockHelmClient struct {
 	cancelWithTimeout         bool
@@ -104,13 +183,13 @@ type mockHelmClient struct {
 
 func (c *mockHelmClient) InstallRelease(ctx context.Context, chartDir, namespace, name string, overrides map[string]interface{}) error {
 	if c.cancelWithTimeout {
-		time.Sleep(120 * time.Millisecond)
+		time.Sleep(1100 * time.Millisecond)
 	}
 	if c.quitWithTimeout {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(2100 * time.Millisecond)
 	}
 	if c.cancelAfterFirstComponent {
-		time.Sleep(80 * time.Millisecond)
+		time.Sleep(300 * time.Millisecond)
 	}
 	return nil
 }
@@ -154,4 +233,45 @@ func newComponents(hc *mockHelmClient) []components.Component {
 		},
 	}
 
+}
+
+type mockProvider struct {
+	hc	*mockHelmClient
+}
+
+func (p *mockProvider) GetComponents() ([]components.Component, error) {
+	return []components.Component{
+		{
+			Name:            "test1",
+			Namespace:       "test1",
+			OverridesGetter: func() map[string]interface{} { return nil },
+			HelmClient:      p.hc,
+			Log:             log.Printf,
+		},
+		{
+			Name:            "test2",
+			Namespace:       "test2",
+			OverridesGetter: func() map[string]interface{} { return nil },
+			HelmClient:      p.hc,
+			Log:             log.Printf,
+		},
+		{
+			Name:            "test3",
+			Namespace:       "test3",
+			OverridesGetter: func() map[string]interface{} { return nil },
+			HelmClient:      p.hc,
+			Log:             log.Printf,
+		},
+	}, nil
+}
+
+type mockOverridesProvider struct {
+
+}
+
+func (o *mockOverridesProvider) OverridesGetterFunctionFor(name string) func() map[string]interface{} {
+	return nil
+}
+func (o *mockOverridesProvider) ReadOverridesFromCluster() error {
+	return nil
 }

--- a/parallel-install/pkg/installation/installation_test.go
+++ b/parallel-install/pkg/installation/installation_test.go
@@ -35,7 +35,7 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 			Log:          log.Printf,
 		})
 
-		err := i.StartKymaInstallation(kubeClient, provider, overridesProvider, eng)
+		err := i.startKymaInstallation(kubeClient, provider, overridesProvider, eng)
 
 		assert.NoError(t, err)
 	})
@@ -56,7 +56,7 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 				Log:          log.Printf,
 			})
 
-			err := i.StartKymaInstallation(kubeClient, provider, overridesProvider, eng)
+			err := i.startKymaInstallation(kubeClient, provider, overridesProvider, eng)
 
 			assert.Error(t, err)
 			assert.EqualError(t, err, "Kyma prerequisites installation failed due to the timeout")
@@ -77,7 +77,7 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 			})
 
 			start := time.Now()
-			err := i.StartKymaInstallation(kubeClient, provider, overridesProvider, eng)
+			err := i.startKymaInstallation(kubeClient, provider, overridesProvider, eng)
 			end := time.Now()
 
 			elapsed := end.Sub(start)
@@ -109,7 +109,7 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 				Log:          log.Printf,
 			})
 
-			err := i.StartKymaInstallation(kubeClient, provider, overridesProvider, eng)
+			err := i.startKymaInstallation(kubeClient, provider, overridesProvider, eng)
 
 			assert.Error(t, err)
 			assert.EqualError(t, err, "Kyma installation failed due to the timeout")
@@ -135,7 +135,7 @@ func TestInstallation_StartKymaInstallation(t *testing.T) {
 			})
 
 			start := time.Now()
-			err := inst.StartKymaInstallation(kubeClient, provider, overridesProvider, eng)
+			err := inst.startKymaInstallation(kubeClient, provider, overridesProvider, eng)
 			end := time.Now()
 
 			elapsed := end.Sub(start)
@@ -169,7 +169,7 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 			Log:          log.Printf,
 		})
 
-		err := i.StartKymaUninstallation(kubeClient, provider, eng)
+		err := i.startKymaUninstallation(kubeClient, provider, eng)
 
 		assert.NoError(t, err)
 	})
@@ -190,7 +190,7 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 				Log:          log.Printf,
 			})
 
-			err := i.StartKymaUninstallation(kubeClient, provider, eng)
+			err := i.startKymaUninstallation(kubeClient, provider, eng)
 
 			assert.Error(t, err)
 			assert.EqualError(t, err, "Kyma uninstallation failed due to the timeout")
@@ -211,7 +211,7 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 			})
 
 			start := time.Now()
-			err := i.StartKymaUninstallation(kubeClient, provider, eng)
+			err := i.startKymaUninstallation(kubeClient, provider, eng)
 			end := time.Now()
 
 			elapsed := end.Sub(start)
@@ -243,7 +243,7 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 				Log:          log.Printf,
 			})
 
-			err := i.StartKymaUninstallation(kubeClient, provider, eng)
+			err := i.startKymaUninstallation(kubeClient, provider, eng)
 
 			assert.Error(t, err)
 			assert.EqualError(t, err, "Kyma prerequisites uninstallation failed due to the timeout")
@@ -269,7 +269,7 @@ func TestInstallation_StartKymaUninstallation(t *testing.T) {
 			})
 
 			start := time.Now()
-			err := inst.StartKymaUninstallation(kubeClient, provider, eng)
+			err := inst.startKymaUninstallation(kubeClient, provider, eng)
 			end := time.Now()
 
 			elapsed := end.Sub(start)

--- a/parallel-install/pkg/prerequisites/prerequisites.go
+++ b/parallel-install/pkg/prerequisites/prerequisites.go
@@ -12,7 +12,7 @@ import (
 
 const logPrefix = "[prerequisites/prerequisites.go]"
 
-func InstallPrerequisites(ctx context.Context, prerequisites []components.Component, kubeClient *kubernetes.Clientset) <-chan error {
+func InstallPrerequisites(ctx context.Context, prerequisites []components.Component, kubeClient kubernetes.Interface) <-chan error {
 
 	statusChan := make(chan error)
 
@@ -52,7 +52,7 @@ func InstallPrerequisites(ctx context.Context, prerequisites []components.Compon
 	return statusChan
 }
 
-func UninstallPrerequisites(ctx context.Context, kubeClient *kubernetes.Clientset, prerequisites []components.Component) <-chan error {
+func UninstallPrerequisites(ctx context.Context, kubeClient kubernetes.Interface, prerequisites []components.Component) <-chan error {
 
 	statusChan := make(chan error)
 

--- a/parallel-install/pkg/prerequisites/prerequisites.go
+++ b/parallel-install/pkg/prerequisites/prerequisites.go
@@ -3,6 +3,7 @@ package prerequisites
 import (
 	"context"
 	"fmt"
+	"github.com/kyma-incubator/hydroform/parallel-install/pkg/config"
 	"log"
 
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/components"
@@ -10,21 +11,32 @@ import (
 
 const logPrefix = "[prerequisites/prerequisites.go]"
 
-func InstallPrerequisites(ctx context.Context, prerequisites []components.Component) error {
+func InstallPrerequisites(ctx context.Context, prerequisites []components.Component) <-chan error {
 
-	for _, prerequisite := range prerequisites {
-		//TODO: Is there a better way to find out if Context is canceled?
-		if ctx.Err() != nil {
-			//Context is canceled or timed-out. Skip processing
-			return fmt.Errorf("Error installing prerequisite %s: %v", prerequisite.Name, ctx.Err())
-		}
-		err := prerequisite.InstallComponent(ctx)
-		if err != nil {
-			return fmt.Errorf("Error installing prerequisite %s: %v", prerequisite.Name, err)
-		}
-	}
+	statusChan := make(chan error)
 
-	return nil
+	go func() {
+		defer close(statusChan)
+
+		for _, prerequisite := range prerequisites {
+			//TODO: Is there a better way to find out if Context is canceled?
+			if ctx.Err() != nil {
+				//Context is canceled or timed-out. Skip processing
+				config.Log("%s Finishing work: %v", logPrefix, ctx.Err())
+				return
+			}
+
+			config.Log("%s Installing component %s ", logPrefix, prerequisite.Name)
+			err := prerequisite.InstallComponent()
+			if err != nil {
+				statusChan <- err
+				return
+			}
+			statusChan <- nil
+		}
+	}()
+
+	return statusChan
 }
 
 func UninstallPrerequisites(ctx context.Context, prerequisites []components.Component) error {

--- a/parallel-install/pkg/prerequisites/prerequisites.go
+++ b/parallel-install/pkg/prerequisites/prerequisites.go
@@ -27,7 +27,7 @@ func InstallPrerequisites(ctx context.Context, prerequisites []components.Compon
 			}
 
 			config.Log("%s Installing component %s ", logPrefix, prerequisite.Name)
-			err := prerequisite.InstallComponent()
+			err := prerequisite.InstallComponent(ctx)
 			if err != nil {
 				statusChan <- err
 				return


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Move namespace creation to prerequisites
- Add prerequisites timeout
- Move some logic to separate functions
- Add installation package tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/kyma/issues/9347