### PR TITLE
Stablize overrides by enforcing map of maps

### DIFF
--- a/parallel-install/go.mod
+++ b/parallel-install/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/cenkalti/backoff/v4 v4.1.0
 	github.com/googleapis/gnostic v0.3.1 // indirect
+	github.com/imdario/mergo v0.3.8
 	github.com/onsi/gomega v1.8.1 // indirect
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect

--- a/parallel-install/pkg/deployment/overrides.go
+++ b/parallel-install/pkg/deployment/overrides.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/imdario/mergo"
 	"gopkg.in/yaml.v3"
 )
 
@@ -41,34 +42,19 @@ func (o *Overrides) Merge() (map[string]interface{}, error) {
 			return nil, err
 		}
 		// merge
-		result = o.mergeMaps(result, fileOverrides)
+		if err := mergo.Map(&result, fileOverrides, mergo.WithOverride); err != nil {
+			return nil, err
+		}
 	}
 
 	//merge overrides
 	for _, override := range o.overrides {
-		result = o.mergeMaps(result, override)
+		if err := mergo.Map(&result, override, mergo.WithOverride); err != nil {
+			return nil, err
+		}
 	}
 
 	return result, nil
-}
-
-func (o *Overrides) mergeMaps(a, b map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(a))
-	for k, v := range a {
-		out[k] = v
-	}
-	for k, v := range b {
-		if v, ok := v.(map[string]interface{}); ok {
-			if bv, ok := out[k]; ok {
-				if bv, ok := bv.(map[string]interface{}); ok {
-					out[k] = o.mergeMaps(bv, v)
-					continue
-				}
-			}
-		}
-		out[k] = v
-	}
-	return out
 }
 
 // AddFile adds overrides defined in a file
@@ -82,7 +68,9 @@ func (o *Overrides) AddFile(file string) error {
 	return fmt.Errorf("Unsupported override file extension. Supported extensions are: %s", strings.Join(supportedFileExt, ", "))
 }
 
-// AddOverrides adds another override
-func (o *Overrides) AddOverrides(overrides map[string]interface{}) {
-	o.overrides = append(o.overrides, overrides)
+// AddOverrides adds overrides for a chart
+func (o *Overrides) AddOverrides(chart string, overrides map[string]interface{}) {
+	overridesMap := make(map[string]interface{})
+	overridesMap[chart] = overrides
+	o.overrides = append(o.overrides, overridesMap)
 }

--- a/parallel-install/pkg/deployment/overrides.go
+++ b/parallel-install/pkg/deployment/overrides.go
@@ -69,8 +69,15 @@ func (o *Overrides) AddFile(file string) error {
 }
 
 // AddOverrides adds overrides for a chart
-func (o *Overrides) AddOverrides(chart string, overrides map[string]interface{}) {
+func (o *Overrides) AddOverrides(chart string, overrides map[string]interface{}) error {
+	if chart == "" {
+		return fmt.Errorf("Chart name cannot be empty when adding overrides")
+	}
+	if len(overrides) < 1 {
+		return fmt.Errorf("Empty overrides map provided for chart '%s'", chart)
+	}
 	overridesMap := make(map[string]interface{})
 	overridesMap[chart] = overrides
 	o.overrides = append(o.overrides, overridesMap)
+	return nil
 }

--- a/parallel-install/pkg/deployment/overrides_test.go
+++ b/parallel-install/pkg/deployment/overrides_test.go
@@ -17,11 +17,13 @@ func Test_MergeOverrides(t *testing.T) {
 
 	override1 := make(map[string]interface{})
 	override1["key4"] = "value4override1"
-	overrides.AddOverrides("chart", override1)
+	err = overrides.AddOverrides("chart", override1)
+	require.NoError(t, err)
 
 	override2 := make(map[string]interface{})
 	override2["key5"] = "value5override2"
-	overrides.AddOverrides("chart", override2)
+	err = overrides.AddOverrides("chart", override2)
+	require.NoError(t, err)
 
 	// read expected result
 	data, err := ioutil.ReadFile("../test/data/deployment-overrides-result.yaml")
@@ -46,4 +48,24 @@ func Test_AddFile(t *testing.T) {
 	require.NoError(t, err)
 	err = overrides.AddFile("../test/data/overrides.xml") // unsupported format
 	require.Error(t, err)
+}
+
+func Test_AddOverrides(t *testing.T) {
+	var err error
+
+	overrides := Overrides{}
+	data := make(map[string]interface{})
+
+	// invalid
+	err = overrides.AddOverrides("", data)
+	require.Error(t, err)
+
+	//invalid
+	err = overrides.AddOverrides("xyz", data)
+	require.Error(t, err)
+
+	//valid
+	data["test"] = "abc"
+	err = overrides.AddOverrides("xyz", data)
+	require.NoError(t, err)
 }

--- a/parallel-install/pkg/deployment/overrides_test.go
+++ b/parallel-install/pkg/deployment/overrides_test.go
@@ -17,11 +17,11 @@ func Test_MergeOverrides(t *testing.T) {
 
 	override1 := make(map[string]interface{})
 	override1["key4"] = "value4override1"
-	overrides.AddOverrides(override1)
+	overrides.AddOverrides("chart", override1)
 
 	override2 := make(map[string]interface{})
 	override2["key5"] = "value5override2"
-	overrides.AddOverrides(override2)
+	overrides.AddOverrides("chart", override2)
 
 	// read expected result
 	data, err := ioutil.ReadFile("../test/data/deployment-overrides-result.yaml")

--- a/parallel-install/pkg/overrides/overrides.go
+++ b/parallel-install/pkg/overrides/overrides.go
@@ -6,6 +6,7 @@ package overrides
 
 import (
 	"context"
+	"fmt"
 
 	"helm.sh/helm/v3/pkg/strvals"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,8 +166,13 @@ func (p *Provider) parseAdditionalOverrides(additionalOverrides map[string]inter
 			if p.componentOverrides[k] == nil {
 				p.componentOverrides[k] = make(map[string]interface{})
 			}
-			p.componentOverrides[k] = MergeMaps(p.componentOverrides[k], v.(map[string]interface{}))
-			p.additionalComponentOverrides[k] = MergeMaps(p.additionalComponentOverrides[k], v.(map[string]interface{}))
+
+			if vTypeSafe, ok := v.(map[string]interface{}); ok {
+				p.componentOverrides[k] = MergeMaps(p.componentOverrides[k], vTypeSafe)
+				p.additionalComponentOverrides[k] = MergeMaps(p.additionalComponentOverrides[k], vTypeSafe)
+			} else {
+				return fmt.Errorf("Cannot add override '%s=%s' as the value has to be a map", k, v)
+			}
 		}
 	}
 

--- a/parallel-install/pkg/overrides/overrides_test.go
+++ b/parallel-install/pkg/overrides/overrides_test.go
@@ -119,4 +119,12 @@ func Test_ReadOverridesFromCluster(t *testing.T) {
 		require.Equal(t, 2, len(res2["global"].(map[string]interface{})), "Number of global overrides not as expected")
 		require.Equal(t, "changed", globalOverrides["globalOverride1"], "Override from additional overrides not on top of regular overrides")
 	})
+
+	t.Run("Test non-nested overrides", func(t *testing.T) {
+		illegalOverrides := make(map[string]interface{})
+		illegalOverrides["componentX"] = "value1"
+		illegalOverrides["componentY"] = "value2"
+		_, err := New(k8sMock, illegalOverrides, log.Printf)
+		require.Error(t, err)
+	})
 }

--- a/parallel-install/pkg/test/data/deployment-overrides-result.yaml
+++ b/parallel-install/pkg/test/data/deployment-overrides-result.yaml
@@ -1,7 +1,8 @@
-key1: value1json
-key2:
-  key2.1: value2.1yaml
-  key2.2: value2.2yaml
-key3: value3json
-key4: value4override1
-key5: value5override2
+chart:
+  key1: value1json
+  key2:
+    key2.1: value2.1yaml
+    key2.2: value2.2yaml
+  key3: value3json
+  key4: value4override1
+  key5: value5override2

--- a/parallel-install/pkg/test/data/deployment-overrides1.yaml
+++ b/parallel-install/pkg/test/data/deployment-overrides1.yaml
@@ -1,4 +1,5 @@
-key1: value1yaml
-key2:
-  key2.1: value2.1yaml
-  key2.2: value2.2yaml
+chart:
+  key1: value1yaml
+  key2:
+    key2.1: value2.1yaml
+    key2.2: value2.2yaml

--- a/parallel-install/pkg/test/data/deployment-overrides2.json
+++ b/parallel-install/pkg/test/data/deployment-overrides2.json
@@ -1,5 +1,7 @@
 {
-    "key1": "value1json",
-    "key3": "value3json",
-    "key4": "value4json"
+    "chart": {
+        "key1": "value1json",
+        "key3": "value3json",
+        "key4": "value4json"
+    }
 }


### PR DESCRIPTION
**Description**

Fire an exception if invalid overrides were provided. Adjust the overrides object in deployment package to ensure component names is provided by user.

**Related issue(s)**

