### PR TITLE
Improve metadata package API for reading

### DIFF
--- a/parallel-install/pkg/deployment/deployment.go
+++ b/parallel-install/pkg/deployment/deployment.go
@@ -52,7 +52,7 @@ func NewDeployment(cfg config.Config, overrides Overrides, kubeClient kubernetes
 		return nil, err
 	}
 
-	metadataProvider := metadata.New(kubeClient, cfg.Profile, cfg.Version)
+	metadataProvider := metadata.New(kubeClient)
 
 	return &Deployment{
 		componentList:    clList,
@@ -71,7 +71,12 @@ func (i *Deployment) StartKymaDeployment() error {
 		return err
 	}
 
-	err = i.metadataProvider.WriteKymaDeploymentInProgress()
+	attr := metadata.Attributes{
+		Version: i.cfg.Version,
+		Profile: i.cfg.Profile,
+	}
+
+	err = i.metadataProvider.WriteKymaDeploymentInProgress(attr)
 	if err != nil {
 		return err
 	}
@@ -83,13 +88,13 @@ func (i *Deployment) StartKymaDeployment() error {
 
 	err = i.startKymaDeployment(prerequisitesProvider, overridesProvider, engine)
 	if err != nil {
-		metaDataErr := i.metadataProvider.WriteKymaDeploymentError(err.Error())
+		metaDataErr := i.metadataProvider.WriteKymaDeploymentError(attr, err.Error())
 		if metaDataErr != nil {
 			return metaDataErr
 		}
 	}
 
-	err = i.metadataProvider.WriteKymaDeployed()
+	err = i.metadataProvider.WriteKymaDeployed(attr)
 	if err != nil {
 		return err
 	}
@@ -104,14 +109,19 @@ func (i *Deployment) StartKymaUninstallation() error {
 		return err
 	}
 
-	err = i.metadataProvider.WriteKymaUninstallationInProgress()
+	attr := metadata.Attributes{
+		Version: i.cfg.Version,
+		Profile: i.cfg.Profile,
+	}
+
+	err = i.metadataProvider.WriteKymaUninstallationInProgress(attr)
 	if err != nil {
 		return err
 	}
 
 	err = i.startKymaUninstallation(prerequisitesProvider, engine)
 	if err != nil {
-		metaDataErr := i.metadataProvider.WriteKymaUninstallationError(err.Error())
+		metaDataErr := i.metadataProvider.WriteKymaUninstallationError(attr, err.Error())
 		if metaDataErr != nil {
 			return metaDataErr
 		}

--- a/parallel-install/pkg/metadata/metadata.go
+++ b/parallel-install/pkg/metadata/metadata.go
@@ -36,13 +36,19 @@ const (
 	Deployed StatusEnum = "Deployed"
 )
 
+//Attributes represents common metadata attributes
+type Attributes struct {
+	Profile string
+	Version string
+}
+
 type MetadataProvider interface {
 	ReadKymaMetadata() (*KymaMetadata, error)
-	WriteKymaDeploymentInProgress() error
-	WriteKymaDeploymentError(error string) error
-	WriteKymaDeployed() error
-	WriteKymaUninstallationInProgress() error
-	WriteKymaUninstallationError(error string) error
+	WriteKymaDeploymentInProgress(attr Attributes) error
+	WriteKymaDeploymentError(attr Attributes, reason string) error
+	WriteKymaDeployed(attr Attributes) error
+	WriteKymaUninstallationInProgress(attr Attributes) error
+	WriteKymaUninstallationError(attr Attributes, reason string) error
 }
 
 type KymaMetadata struct {
@@ -54,15 +60,11 @@ type KymaMetadata struct {
 
 type Provider struct {
 	kubeClient kubernetes.Interface
-	profile    string
-	version    string
 }
 
-func New(client kubernetes.Interface, profile, version string) MetadataProvider {
+func New(client kubernetes.Interface) MetadataProvider {
 	return &Provider{
 		kubeClient: client,
-		profile:    profile,
-		version:    version,
 	}
 }
 
@@ -93,10 +95,10 @@ func (p *Provider) ReadKymaMetadata() (*KymaMetadata, error) {
 	return kymaMetaData, nil
 }
 
-func (p *Provider) WriteKymaDeploymentInProgress() error {
+func (p *Provider) WriteKymaDeploymentInProgress(attr Attributes) error {
 	meta := &KymaMetadata{
-		Version: p.version,
-		Profile: p.profile,
+		Version: attr.Version,
+		Profile: attr.Profile,
 		Status:  DeploymentInProgress,
 	}
 
@@ -105,10 +107,10 @@ func (p *Provider) WriteKymaDeploymentInProgress() error {
 	})
 }
 
-func (p *Provider) WriteKymaUninstallationInProgress() error {
+func (p *Provider) WriteKymaUninstallationInProgress(attr Attributes) error {
 	meta := &KymaMetadata{
-		Version: p.version,
-		Profile: p.profile,
+		Version: attr.Version,
+		Profile: attr.Profile,
 		Status:  UninstallationInProgress,
 	}
 
@@ -117,10 +119,10 @@ func (p *Provider) WriteKymaUninstallationInProgress() error {
 	})
 }
 
-func (p *Provider) WriteKymaDeploymentError(reason string) error {
+func (p *Provider) WriteKymaDeploymentError(attr Attributes, reason string) error {
 	meta := &KymaMetadata{
-		Version: p.version,
-		Profile: p.profile,
+		Version: attr.Version,
+		Profile: attr.Profile,
 		Status:  DeploymentError,
 		Reason:  reason,
 	}
@@ -130,10 +132,10 @@ func (p *Provider) WriteKymaDeploymentError(reason string) error {
 	})
 }
 
-func (p *Provider) WriteKymaUninstallationError(reason string) error {
+func (p *Provider) WriteKymaUninstallationError(attr Attributes, reason string) error {
 	meta := &KymaMetadata{
-		Version: p.version,
-		Profile: p.profile,
+		Version: attr.Version,
+		Profile: attr.Profile,
 		Status:  UninstallationError,
 		Reason:  reason,
 	}
@@ -143,10 +145,10 @@ func (p *Provider) WriteKymaUninstallationError(reason string) error {
 	})
 }
 
-func (p *Provider) WriteKymaDeployed() error {
+func (p *Provider) WriteKymaDeployed(attr Attributes) error {
 	meta := &KymaMetadata{
-		Version: p.version,
-		Profile: p.profile,
+		Version: attr.Version,
+		Profile: attr.Profile,
 		Status:  Deployed,
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Existing `metadata.New` function takes a kube client, as well as a version and a profile as parameters. The version and the profile are only required if you want to use the provider to write metadata. The `ReadKymaMetadata` function does not require them. So if a client is only interested in reading, it has to provide empty strings, which is not nice. The PR is moving the version and the profile from the `New` function to the `Write...` functions and bundles them into a struct to avoid code duplication.

**Related issue(s)**
See also https://github.com/kyma-project/cli/issues/698`
