### PR TITLE
Fix bug ignoring return error when installation fails

### DIFF
--- a/parallel-install/pkg/deployment/deployment.go
+++ b/parallel-install/pkg/deployment/deployment.go
@@ -66,14 +66,11 @@ func (i *Deployment) StartKymaDeployment() error {
 		if metaDataErr != nil {
 			return metaDataErr
 		}
-	}
-
-	err = i.metadataProvider.WriteKymaDeployed(attr)
-	if err != nil {
 		return err
 	}
 
-	return nil
+	err = i.metadataProvider.WriteKymaDeployed(attr)
+	return err
 }
 
 func (i *Deployment) startKymaDeployment(prerequisitesProvider components.Provider, overridesProvider overrides.OverridesProvider, eng *engine.Engine) error {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Parallel install was not returning errors when components would fail installing. Making jobs run tests even when installation was not successful: https://status.build.kyma-project.io/?job=kyma-integration-gardener-gcp-parallel

