### PR TITLE
Turn overrides to pointer when passed down to parallel install

### DIFF
--- a/parallel-install/example/example.go
+++ b/parallel-install/example/example.go
@@ -47,10 +47,10 @@ func main() {
 		log.Fatalf("Unable to build kubernetes configuration. Error: %v", err)
 	}
 
-	overrides := deployment.Overrides{}
+	overrides := &deployment.Overrides{}
 	overrides.AddFile("./overrides.yaml")
 
-	installationCfg := config.Config{
+	installationCfg := &config.Config{
 		WorkersCount:                  4,
 		CancelTimeout:                 20 * time.Minute,
 		QuitTimeout:                   25 * time.Minute,

--- a/parallel-install/pkg/components/component.go
+++ b/parallel-install/pkg/components/component.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"context"
+
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/helm"
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/logger"
 )

--- a/parallel-install/pkg/components/components.go
+++ b/parallel-install/pkg/components/components.go
@@ -2,8 +2,9 @@ package components
 
 import (
 	"fmt"
-	"github.com/kyma-incubator/hydroform/parallel-install/pkg/logger"
 	"path"
+
+	"github.com/kyma-incubator/hydroform/parallel-install/pkg/logger"
 
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/config"
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/helm"
@@ -30,7 +31,7 @@ type ComponentsProvider struct {
 //resourcesPath is a directory where subdirectories of components' charts are located.
 //
 //componentListYaml is a string containing YAML with an Installation CR.
-func NewComponentsProvider(overridesProvider overrides.OverridesProvider, resourcesPath string, components []ComponentDefinition, cfg config.Config) *ComponentsProvider {
+func NewComponentsProvider(overridesProvider overrides.OverridesProvider, resourcesPath string, components []ComponentDefinition, cfg *config.Config) *ComponentsProvider {
 
 	helmCfg := helm.Config{
 		HelmTimeoutSeconds:            cfg.HelmTimeoutSeconds,

--- a/parallel-install/pkg/components/components_test.go
+++ b/parallel-install/pkg/components/components_test.go
@@ -1,8 +1,9 @@
 package components
 
 import (
-	"github.com/kyma-incubator/hydroform/parallel-install/pkg/logger"
 	"testing"
+
+	"github.com/kyma-incubator/hydroform/parallel-install/pkg/logger"
 
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/config"
 
@@ -32,14 +33,14 @@ func Test_GetComponents(t *testing.T) {
 	overridesProvider, err := overrides.New(k8sMock, make(map[string]interface{}), logger.NewLogger(true))
 	require.NoError(t, err)
 
-	installationCfg := config.Config{}
+	installationCfg := &config.Config{}
 
 	components := []ComponentDefinition{
-		ComponentDefinition{
+		{
 			Name:      "comp1",
 			Namespace: "ns1",
 		},
-		ComponentDefinition{
+		{
 			Name:      "comp2",
 			Namespace: "ns2",
 		},

--- a/parallel-install/pkg/components/prerequisites.go
+++ b/parallel-install/pkg/components/prerequisites.go
@@ -1,8 +1,9 @@
 package components
 
 import (
-	"github.com/kyma-incubator/hydroform/parallel-install/pkg/logger"
 	"path"
+
+	"github.com/kyma-incubator/hydroform/parallel-install/pkg/logger"
 
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/config"
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/helm"
@@ -25,7 +26,7 @@ type PrerequisitesProvider struct {
 //resourcesPath is a directory where subdirectories of components' charts are located.
 //
 //componentList is a slice of pairs: [component-name, namespace]
-func NewPrerequisitesProvider(overridesProvider overrides.OverridesProvider, resourcesPath string, components []ComponentDefinition, cfg config.Config) *PrerequisitesProvider {
+func NewPrerequisitesProvider(overridesProvider overrides.OverridesProvider, resourcesPath string, components []ComponentDefinition, cfg *config.Config) *PrerequisitesProvider {
 	helmCfg := helm.Config{
 		HelmTimeoutSeconds:            cfg.HelmTimeoutSeconds,
 		BackoffInitialIntervalSeconds: cfg.BackoffInitialIntervalSeconds,

--- a/parallel-install/pkg/components/prerequisites_test.go
+++ b/parallel-install/pkg/components/prerequisites_test.go
@@ -1,8 +1,9 @@
 package components
 
 import (
-	"github.com/kyma-incubator/hydroform/parallel-install/pkg/logger"
 	"testing"
+
+	"github.com/kyma-incubator/hydroform/parallel-install/pkg/logger"
 
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/config"
 
@@ -38,7 +39,7 @@ func Test_PrerequisiteGetComponents(t *testing.T) {
 	}
 	componentList := []ComponentDefinition{compDef}
 
-	installationCfg := config.Config{}
+	installationCfg := &config.Config{}
 
 	provider := NewPrerequisitesProvider(overridesProvider, "", componentList, installationCfg)
 

--- a/parallel-install/pkg/deployment/core.go
+++ b/parallel-install/pkg/deployment/core.go
@@ -23,8 +23,8 @@ var incompatibleLocalComponents = []string{"apiserver-proxy", "iam-kubeconfig-se
 type core struct {
 	// Contains list of components to install (inclusive pre-requisites)
 	componentList *components.ComponentList
-	cfg           config.Config
-	overrides     Overrides
+	cfg           *config.Config
+	overrides     *Overrides
 	// Used to send progress events of a running install/uninstall process
 	processUpdates   chan<- ProcessUpdate
 	kubeClient       kubernetes.Interface
@@ -40,7 +40,7 @@ type core struct {
 //kubeClient is the kubernetes client
 //
 //processUpdates can be an optional feedback channel provided by the caller
-func newCore(cfg config.Config, overrides Overrides, kubeClient kubernetes.Interface, processUpdates chan<- ProcessUpdate) (*core, error) {
+func newCore(cfg *config.Config, overrides *Overrides, kubeClient kubernetes.Interface, processUpdates chan<- ProcessUpdate) (*core, error) {
 	clList, err := components.NewComponentList(cfg.ComponentsListFile)
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func newCore(cfg config.Config, overrides Overrides, kubeClient kubernetes.Inter
 		removeFromComponentList(clList, incompatibleLocalComponents)
 	}
 
-	registerOverridesInterceptors(&overrides)
+	registerOverridesInterceptors(overrides)
 
 	metadataProvider := metadata.New(kubeClient)
 

--- a/parallel-install/pkg/deployment/deletion.go
+++ b/parallel-install/pkg/deployment/deletion.go
@@ -28,7 +28,7 @@ type Deletion struct {
 }
 
 //NewDeletion creates a new Deployment instance for deleting Kyma on a cluster.
-func NewDeletion(cfg config.Config, overrides Overrides, kubeClient kubernetes.Interface, processUpdates chan<- ProcessUpdate) (*Deletion, error) {
+func NewDeletion(cfg *config.Config, overrides *Overrides, kubeClient kubernetes.Interface, processUpdates chan<- ProcessUpdate) (*Deletion, error) {
 	if err := cfg.ValidateDeletion(); err != nil {
 		return nil, err
 	}

--- a/parallel-install/pkg/deployment/deletion_test.go
+++ b/parallel-install/pkg/deployment/deletion_test.go
@@ -170,13 +170,13 @@ func TestDeployment_StartKymaUninstallation(t *testing.T) {
 
 // Pass optionally an receiver-channel to get progress updates
 func newDeletion(t *testing.T, procUpdates chan<- ProcessUpdate, kubeClient kubernetes.Interface) *Deletion {
-	config := config.Config{
+	config := &config.Config{
 		CancelTimeout:      cancelTimeout,
 		QuitTimeout:        quitTimeout,
 		Log:                logger.NewLogger(true),
 		ComponentsListFile: "../test/data/componentlist.yaml",
 	}
-	core, err := newCore(config, Overrides{}, kubeClient, procUpdates)
+	core, err := newCore(config, &Overrides{}, kubeClient, procUpdates)
 	if err != nil {
 		assert.NoError(t, err)
 	}

--- a/parallel-install/pkg/deployment/deployment.go
+++ b/parallel-install/pkg/deployment/deployment.go
@@ -25,7 +25,7 @@ type Deployment struct {
 }
 
 //NewDeployment creates a new Deployment instance for deploying Kyma on a cluster.
-func NewDeployment(cfg config.Config, overrides Overrides, kubeClient kubernetes.Interface, processUpdates chan<- ProcessUpdate) (*Deployment, error) {
+func NewDeployment(cfg *config.Config, overrides *Overrides, kubeClient kubernetes.Interface, processUpdates chan<- ProcessUpdate) (*Deployment, error) {
 	if err := cfg.ValidateDeployment(); err != nil {
 		return nil, err
 	}

--- a/parallel-install/pkg/deployment/deployment_test.go
+++ b/parallel-install/pkg/deployment/deployment_test.go
@@ -2,8 +2,9 @@ package deployment
 
 import (
 	"fmt"
-	"github.com/kyma-incubator/hydroform/parallel-install/pkg/logger"
 	"sync"
+
+	"github.com/kyma-incubator/hydroform/parallel-install/pkg/logger"
 
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/config"
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/engine"
@@ -233,13 +234,13 @@ func TestDeployment_StartKymaDeployment(t *testing.T) {
 
 // Pass optionally an receiver-channel to get progress updates
 func newDeployment(t *testing.T, procUpdates chan<- ProcessUpdate, kubeClient kubernetes.Interface) *Deployment {
-	config := config.Config{
+	config := &config.Config{
 		CancelTimeout:      cancelTimeout,
 		QuitTimeout:        quitTimeout,
 		Log:                logger.NewLogger(true),
 		ComponentsListFile: "../test/data/componentlist.yaml",
 	}
-	core, err := newCore(config, Overrides{}, kubeClient, procUpdates)
+	core, err := newCore(config, &Overrides{}, kubeClient, procUpdates)
 	if err != nil {
 		assert.NoError(t, err)
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Turn overrides to pointer when passed down to parallel install so that we can get updated values on the CLI.

**Related issue(s)**
https://github.com/kyma-project/cli/issues/702