### PR TITLE
Set default namespace in component-list to kyma-system

### DIFF
--- a/parallel-install/pkg/components/componentlist.go
+++ b/parallel-install/pkg/components/componentlist.go
@@ -65,7 +65,9 @@ func NewComponentList(componentsListPath string) (*ComponentList, error) {
 		return nil, err
 	}
 
-	var compListData *ComponentListData
+	var compListData *ComponentListData = &ComponentListData{
+		DefaultNamespace: "kyma-system",
+	}
 	fileExt := filepath.Ext(componentsListPath)
 	if fileExt == ".json" {
 		if err := json.Unmarshal(data, &compListData); err != nil {


### PR DESCRIPTION
**Description**

The field `defaultNamespace` is now optional in the component list file.

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/10297
