### PR TITLE
Fix Logger output for many logging arguments

### DIFF
--- a/parallel-install/pkg/logger/logger.go
+++ b/parallel-install/pkg/logger/logger.go
@@ -76,33 +76,33 @@ func getDevelopmentConfig() zap.Config {
 }
 
 func (l *Logger) Info(args ...interface{}) {
-	l.internalLogger.Info(args)
+	l.internalLogger.Info(args...)
 }
 
 func (l *Logger) Infof(template string, args ...interface{}) {
-	l.internalLogger.Infof(template, args)
+	l.internalLogger.Infof(template, args...)
 }
 
 func (l *Logger) Warn(args ...interface{}) {
-	l.internalLogger.Warn(args)
+	l.internalLogger.Warn(args...)
 }
 
 func (l *Logger) Warnf(template string, args ...interface{}) {
-	l.internalLogger.Warnf(template, args)
+	l.internalLogger.Warnf(template, args...)
 }
 
 func (l *Logger) Error(args ...interface{}) {
-	l.internalLogger.Error(args)
+	l.internalLogger.Error(args...)
 }
 
 func (l *Logger) Errorf(template string, args ...interface{}) {
-	l.internalLogger.Errorf(template, args)
+	l.internalLogger.Errorf(template, args...)
 }
 
 func (l *Logger) Fatal(args ...interface{}) {
-	l.internalLogger.Fatal(args)
+	l.internalLogger.Fatal(args...)
 }
 
 func (l *Logger) Fatalf(template string, args ...interface{}) {
-	l.internalLogger.Fatalf(template, args)
+	l.internalLogger.Fatalf(template, args...)
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Some Logger output that required passing many arguments did not provide correct output, as values were missing.
Before fix:
`2021-03-12T11:52:19.734+0100	INFO	logger/logger.go:83	[[helm/client.go] istio istio-system] Starting upgrade for release %!s(MISSING) in namespace %!s(MISSING)`
After fix:
`2021-03-12T12:35:09.061+0100	INFO	logger/logger.go:83	[helm/client.go] Starting upgrade for release istio in namespace istio-system`

Changes proposed in this pull request:

- take into account all Logger arguments passed in internal logger methods' calls

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #169 